### PR TITLE
Allow creating frontend.Documents for io.Writers

### DIFF
--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"io"
 	"os"
 	"time"
 
@@ -37,18 +38,30 @@ func initDocument() *Document {
 	return d
 }
 
-// New creates a new PDF file. After Doc.Finish() is called, the file is closed.
+// New creates a new document writing to a new PDF file
+// with the given filename. New DOES NOT close this file.
 func New(filename string) (*Document, error) {
 	w, err := os.Create(filename)
 	if err != nil {
 		return nil, err
 	}
+
+    fe, err := NewForWriter(w)
+    if err != nil {
+        return nil, err
+    }
+
+    fe.Doc.Filename = filename
+    return fe, nil
+}
+
+// NewForWriter creates a new Document writing to w. w is never closed.
+func NewForWriter(w io.Writer) (*Document, error) {
 	fe := initDocument()
 	fe.Doc = document.NewDocument(w)
-	if err = fe.RegisterCallback(CallbackPostLinebreak, PostLinebreakCallbackFunc(postLinebreak)); err != nil {
+    if err := fe.RegisterCallback(CallbackPostLinebreak, PostLinebreakCallbackFunc(postLinebreak)); err != nil {
 		return nil, err
 	}
-	fe.Doc.Filename = filename
 	return fe, nil
 }
 


### PR DESCRIPTION
Hey there,

I was trying to get a small example running using boxesandglue. However, I found myself wanting to create Documents writing to arbitrary io.Writers instead of os.Files. That's why I made this PR.

If I overlooked something, please let me know. Thanks for the great work :heart: