### PR TITLE
Fix text rise (Ts) state leaking between text objects

### DIFF
--- a/backend/document/document.go
+++ b/backend/document/document.go
@@ -212,6 +212,11 @@ func (oc *objectContext) gotoTextMode(newMode TextScope) {
 				oc.writef("100 Tz ")
 				oc.currentExpand = 0
 			}
+			// Reset text rise (Ts) at start of each text object.
+			// PDF text state persists across BT...ET blocks, but objectContext
+			// is created fresh for each object with currentVShift=0. Without this
+			// reset, a non-zero Ts from a previous object would persist.
+			oc.writef("0 Ts ")
 			oc.textmode = ScopeText
 		}
 		if oc.textmode == ScopeText && newMode < oc.textmode {


### PR DESCRIPTION
When multiple text objects are rendered on a page, the PDF text rise state (Ts operator) was persisting across BT...ET blocks. Each objectContext is created fresh with currentVShift=0, but the PDF's actual text rise state from a previous object remained active. 

This caused glyphs with YOffset=0 to render at incorrect vertical positions if a previous text object had set a non-zero text rise (e.g., for combining marks or diacritics).                                                                                
                                                                                                                                                                                                                                                               
The fix explicitly resets text rise to 0 when starting each new text object (BT), ensuring consistent baseline positioning regardless of what previous objects rendered.   